### PR TITLE
Fix unit tests and add repo quality of life improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+composer.phar
+/vendor/
+/.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.phar
 /vendor/
 /.idea/
+.phpunit.result.cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Types of changes
 
 ### Added
 * .gitignore
+* PHP extension requirements
+
+### Fixed
+* Broken unit tests in ImageResponseTest
 
 ## 1.0.0 - [Date]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Types of changes
 
 ## [Unreleased]
 
+### Added
+* .gitignore
+
 ## 1.0.0 - [Date]
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Out of the box solution for Glide PHP for Laravel
 Requirements
 ------------
 
-* PHP >= 7.3;
+* PHP >= 7.3 with the following extensions:
+  * Exif
+  * GD
 * league/glide-laravel": "^1.0",
 
 Features

--- a/src/Util/GlideUrl.php
+++ b/src/Util/GlideUrl.php
@@ -56,6 +56,14 @@ class GlideUrl
     }
 
     /**
+     * @return string
+     */
+    public function getParsedPath():string
+    {
+        return $this->parsedPath();
+    }
+
+    /**
      * Parse either single or multiple presets
      *
      * @param $presets

--- a/tests/Feature/GlideServerServiceProviderTest.php
+++ b/tests/Feature/GlideServerServiceProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Tests\TestCase;
+use AmpedWeb\GlideInABox\Util\GlideUrl;
+use Config;
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use League\Glide\Api\Api;
+use League\Glide\Manipulators\Watermark;
+use League\Glide\Server;
+
+class GlideServerServiceProviderTest extends TestCase
+{
+    public function testWatermarksConfigurationIsParsed()
+    {
+        $watermarkPath = 'foo';
+        $watermarkPathPrefix = 'bar';
+
+        Config::set('glideinabox.watermarks', $watermarkPath);
+        Config::set('glideinabox.watermarks_path_prefix', $watermarkPathPrefix);
+
+        $server = $this->app->make(Server::class);
+
+
+        // This is completely sketchy.  Server::getApi() returns an
+        // instance of ApiInterface.  But we believe strongly that
+        // it will always be an instance of Api.  Therefore we are
+        // going to rely on concretions instead of abstractions.
+        // I feel so dirty about this.
+
+        $api = $server->getApi();
+
+        // Still, at least we can assert its type.  Small consolation.
+        $this->assertInstanceOf(Api::class, $api);
+
+        $manipulators = $api->getManipulators();
+
+        $watermarkManipulator = null;
+        foreach ($manipulators as $key => $value) {
+            if ($value instanceof Watermark) {
+                $watermarkManipulator = $value;
+            }
+        }
+
+        $this->assertInstanceOf(Watermark::class, $watermarkManipulator);
+
+        $this->assertEquals($watermarkPathPrefix, $watermarkManipulator->getWatermarksPathPrefix());
+
+        /** @var Filesystem $watermarksFlysystem */
+        $watermarksFlysystem = $watermarkManipulator->getWatermarks();
+        $this->assertInstanceOf(Filesystem::class, $watermarksFlysystem);
+
+        /** @var Local $adapter */
+        $adapter = $watermarksFlysystem->getAdapter();
+        $this->assertInstanceOf(Local::class, $adapter);
+
+        $this->assertEquals($watermarkPath . '/', $adapter->getPathPrefix());
+    }
+
+    public function testMakeGlideUrlBinding()
+    {
+        $glideUrl = $this->app->make(GlideUrl::class);
+
+        $this->assertInstanceOf(GlideUrl::class, $glideUrl);
+    }
+}

--- a/tests/Feature/GlideServerServiceProviderTest.php
+++ b/tests/Feature/GlideServerServiceProviderTest.php
@@ -60,6 +60,9 @@ class GlideServerServiceProviderTest extends TestCase
         $this->assertInstanceOf(Local::class, $adapter);
 
         $this->assertEquals($watermarkPath . '/', $adapter->getPathPrefix());
+
+        /* Clean up created directory.  Yes, really. */
+        rmdir(__DIR__ . '/../../foo');
     }
 
     public function testMakeGlideUrlBinding()

--- a/tests/Feature/GlideServerServiceProviderTest.php
+++ b/tests/Feature/GlideServerServiceProviderTest.php
@@ -4,6 +4,7 @@
 namespace AmpedWeb\GlideInABox\Tests\Feature;
 
 
+use AmpedWeb\GlideInABox\Providers\GlideServerServiceProvider;
 use AmpedWeb\GlideInABox\Tests\TestCase;
 use AmpedWeb\GlideInABox\Util\GlideUrl;
 use Config;
@@ -66,5 +67,11 @@ class GlideServerServiceProviderTest extends TestCase
         $glideUrl = $this->app->make(GlideUrl::class);
 
         $this->assertInstanceOf(GlideUrl::class, $glideUrl);
+    }
+
+    public function testServiceProvidesServer()
+    {
+        $service = new GlideServerServiceProvider($this->app);
+        $this->assertContains(Server::class, $service->provides());
     }
 }

--- a/tests/Feature/GlideSignatureValidationServiceProviderTest.php
+++ b/tests/Feature/GlideSignatureValidationServiceProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Providers\GlideSignatureValidationServiceProvider;
+use AmpedWeb\GlideInABox\Services\GlideSignatureValidationService;
+use AmpedWeb\GlideInABox\Tests\TestCase;
+
+class GlideSignatureValidationServiceProviderTest extends TestCase
+{
+    public function testServiceProvidesSignatureValidationService()
+    {
+        $service = new GlideSignatureValidationServiceProvider($this->app);
+        $this->assertContains(GlideSignatureValidationService::class, $service->provides());
+    }
+}

--- a/tests/Feature/GlideSignatureValidationServiceTest.php
+++ b/tests/Feature/GlideSignatureValidationServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Services\GlideSignatureValidationService;
+use AmpedWeb\GlideInABox\Tests\TestCase;
+
+class GlideSignatureValidationServiceTest extends TestCase
+{
+    public function testValidateProcessesACallbackOnError()
+    {
+        $service = $this->app->make(GlideSignatureValidationService::class);
+
+        $expectedResponse = 'Foo';
+
+        $callback = function () use ($expectedResponse) {
+            return $expectedResponse;
+        };
+
+        $response = $service->validate('/this/will/fail', $callback);
+
+        $this->assertEquals($expectedResponse, $response);
+    }
+}

--- a/tests/Feature/GlideUrlTest.php
+++ b/tests/Feature/GlideUrlTest.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Tests\TestCase;
+use AmpedWeb\GlideInABox\Util\GlideUrl;
+
+class GlideUrlTest extends TestCase
+{
+    public function testParsedPathRemovesFirstInstanceOfStorage()
+    {
+        $glideUrl = new GlideUrl();
+        $glideUrl->setPath('/storage/foo/bar');
+        $this->assertEquals('foo/bar', $glideUrl->getParsedPath());
+    }
+}

--- a/tests/Feature/ImageResponseTest.php
+++ b/tests/Feature/ImageResponseTest.php
@@ -7,13 +7,13 @@ namespace AmpedWeb\GlideInABox\Tests\Feature;
 use AmpedWeb\GlideInABox\Tests\TestCase;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Http\File;
-use Intervention\Image\Facades\Image;
 
 class ImageResponseTest extends TestCase
 {
 
-    protected function putImage()
+    public function setUp(): void
     {
+        parent::setUp();
         $testImageFile = __DIR__ . '/../fixtures/cat.png';
         $this->assertFileExists($testImageFile);
         $testImageFile = new File($testImageFile);
@@ -22,10 +22,7 @@ class ImageResponseTest extends TestCase
 
     public function testCustomImageResponse()
     {
-
-        $this->putImage();
-
-        $glideUrl = glide_url('cat.png')->custom(['w' => 200]);
+        $glideUrl = glide_url('/cat.png')->custom(['w' => 200]);
 
         $imgResponse = $this->get($glideUrl);
 
@@ -37,8 +34,6 @@ class ImageResponseTest extends TestCase
 
     public function testPresetImageResponse()
     {
-        $this->putImage();
-
         $glideUrl = glide_url('cat.png')->preset('large');
 
         $imgResponse = $this->get($glideUrl);
@@ -50,9 +45,6 @@ class ImageResponseTest extends TestCase
 
     public function testPresetImageResponseWithArray()
     {
-
-        $this->putImage();
-
         $glideUrl = glide_url('cat.png')->preset(['large']);
 
         $imgResponse = $this->get($glideUrl);
@@ -64,9 +56,6 @@ class ImageResponseTest extends TestCase
 
     public function testNoSignatureResponse()
     {
-
-        $this->putImage();
-
         $glideUrl = glide_url('cat.png')->preset(['large']);
 
         //Lets remove our signature from the URL
@@ -79,7 +68,7 @@ class ImageResponseTest extends TestCase
 
         unset($queries['s']);
 
-        $noSigUrl = $baseUrl.='?'.http_build_query($queries);
+        $noSigUrl = $baseUrl . '?' . http_build_query($queries);
 
         $imgResponse = $this->get($noSigUrl);
 

--- a/tests/Feature/SignatureServiceProviderTest.php
+++ b/tests/Feature/SignatureServiceProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Providers\SignatureServiceProvider;
+use AmpedWeb\GlideInABox\Tests\TestCase;
+use League\Glide\Signatures\Signature;
+
+class SignatureServiceProviderTest extends TestCase
+{
+    public function testServiceProvidesSignatureService()
+    {
+        $provider = new SignatureServiceProvider($this->app);
+        $this->assertContains(Signature::class, $provider->provides());
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,14 @@
 
 namespace AmpedWeb\GlideInABox\Tests;
 
+use AmpedWeb\GlideInABox\Providers\GlideInABoxRoutesProvider;
 use AmpedWeb\GlideInABox\Providers\GlideServerServiceProvider;
 use AmpedWeb\GlideInABox\Providers\GlideSignatureValidationServiceProvider;
 use AmpedWeb\GlideInABox\Providers\SignatureServiceProvider;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Routing\RouteCollection;
+use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Monolog\Formatter\LineFormatter;
@@ -15,6 +20,10 @@ class TestCase extends \Orchestra\Testbench\TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        /** @var Router $router */
+        $router = $this->app->get('router');
+
         Artisan::call('storage:link');
         // additional setup
         //Set our glideinabox config
@@ -24,7 +33,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
                 'signature_key'     => '9e83e05bbf9b5db17ac0deec3b7ce6cba983f6dc50531c7a919f28d5fb3696c3',
                 'cache_path_prefix' => '.cache',
                 'source'            => public_path('storage'),
-                'base_url'          => 'img',
+                'base_url'          => '',
                 'max_image_size'    => 50 * 50,
                 'presets'           => [
                     'small'  => [
@@ -47,7 +56,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
         return [
             GlideServerServiceProvider::class,
             GlideSignatureValidationServiceProvider::class,
-            SignatureServiceProvider::class
+            SignatureServiceProvider::class,
+            GlideInABoxRoutesProvider::class
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,23 +6,14 @@ use AmpedWeb\GlideInABox\Providers\GlideInABoxRoutesProvider;
 use AmpedWeb\GlideInABox\Providers\GlideServerServiceProvider;
 use AmpedWeb\GlideInABox\Providers\GlideSignatureValidationServiceProvider;
 use AmpedWeb\GlideInABox\Providers\SignatureServiceProvider;
-use Illuminate\Config\Repository;
-use Illuminate\Container\Container;
-use Illuminate\Routing\RouteCollection;
-use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
-use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\StreamHandler;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {
     public function setUp(): void
     {
         parent::setUp();
-
-        /** @var Router $router */
-        $router = $this->app->get('router');
 
         Artisan::call('storage:link');
         // additional setup
@@ -59,12 +50,5 @@ class TestCase extends \Orchestra\Testbench\TestCase
             SignatureServiceProvider::class,
             GlideInABoxRoutesProvider::class
         ];
-    }
-
-    /**
-     * Setup logging
-     */
-    protected function getEnvironmentSetUp($app)
-    {
     }
 }


### PR DESCRIPTION
## Quality of life
I've added a .gitignore, which will exclude `/vendor`, PHPStorm and PHPUnit files.  

There are also a couple of PHP extensions which are required by the package.  I've added these to the README.

## Unit tests
I found that the unit tests were broken on a clean installation of the package.  The cause was found to be an incorrect path mapping in TestCase.  This pull request fixes that.  In addition, I made a small modification to ImageResponseTest so that it uses the  more conventional PHPUnit `setUp()` method to set up the testing environment prior to each test.