### PR TITLE
Feature/watermarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Types of changes
 * DimensionParser Trait
 * ColourParser Trait
 * Background Trait
+* Watermarks Trait
 
 ### Changed
 * GlideUrl::preset starts an image builder instead of returning an image URL

--- a/src/Exceptions/InvalidMarkException.php
+++ b/src/Exceptions/InvalidMarkException.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Exceptions;
+
+
+use Exception;
+
+class InvalidMarkException extends Exception
+{
+
+}

--- a/src/Exceptions/InvalidMarkFitException.php
+++ b/src/Exceptions/InvalidMarkFitException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Exceptions;
+
+
+class InvalidMarkFitException extends InvalidMarkException
+{
+
+}

--- a/src/Exceptions/InvalidMarkPositionException.php
+++ b/src/Exceptions/InvalidMarkPositionException.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Exceptions;
+
+
+class InvalidMarkPositionException extends InvalidMarkException
+{
+
+}

--- a/src/Traits/Watermarks.php
+++ b/src/Traits/Watermarks.php
@@ -1,0 +1,257 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Traits;
+
+use AmpedWeb\GlideInABox\Exceptions\InvalidDimensionException;
+use AmpedWeb\GlideInABox\Exceptions\InvalidMarkFitException;
+use AmpedWeb\GlideInABox\Exceptions\InvalidMarkPositionException;
+
+/**
+ * This trait provides watermarks functionality
+ *
+ * @package AmpedWeb\GlideInABox\Traits
+ * @link    https://glide.thephpleague.com/1.0/api/watermarks/
+ */
+trait Watermarks
+{
+    use DimensionParser;
+
+    /**
+     * @property array $buildParams
+     */
+
+    /** @var string  */
+    public static $MARKPOS_TOP_LEFT = 'top-left';
+
+    /** @var string  */
+    public static $MARKPOS_TOP = 'top';
+
+    /** @var string  */
+    public static $MARKPOS_TOP_RIGHT = 'top-right';
+
+    /** @var string  */
+    public static $MARKPOS_LEFT = 'left';
+
+    /** @var string  */
+    public static $MARKPOS_CENTER = 'center';
+
+    /** @var string  */
+    public static $MARKPOS_RIGHT = 'right';
+
+    /** @var string  */
+    public static $MARKPOS_BOTTOM_LEFT = 'bottom-left';
+
+    /** @var string  */
+    public static $MARKPOS_BOTTOM = 'bottom';
+
+    /** @var string  */
+    public static $MARKPOS_BOTTOM_RIGHT = 'bottom-right';
+
+    /**
+     * Adds a watermark to the image.
+     *
+     * Must be a path to an image in the watermarks file system, as configured in your server.
+     *
+     * @param string $filename
+     *
+     * @return Watermarks
+     */
+    public function mark(string $filename)
+    {
+        $this->buildParams['mark'] = $filename;
+
+        return $this;
+    }
+
+    /**
+     * Sets the width of the watermark in pixels, or using relative dimensions.
+     *
+     * @param string $dimension
+     *
+     * @return Watermarks
+     * @throws InvalidDimensionException
+     */
+    public function markWidth(string $dimension)
+    {
+        $this->buildParams['markw'] = $this->parseDimension($dimension);
+
+        return $this;
+    }
+
+    /**
+     * Sets the height of the watermark in pixels, or using relative dimensions.
+     *
+     * @param string $dimension
+     *
+     * @return Watermarks
+     * @throws InvalidDimensionException
+     */
+    public function markHeight(string $dimension)
+    {
+        $this->buildParams['markh'] = $this->parseDimension($dimension);
+
+        return $this;
+    }
+
+    /**
+     * Sets how the watermark is fitted to its target dimensions.
+     *
+     * Accepts:
+     *
+     * - `contain`: Default. Resizes the image to fit within the width and height boundaries without cropping,
+     * distorting or altering the aspect ratio.
+     * - `max`: Resizes the image to fit within the width and height boundaries without cropping, distorting or
+     * altering the aspect ratio, and will also not increase the size of the image if it is smaller than the output
+     * size.
+     * - `fill`: Resizes the image to fit within the width and height boundaries without cropping or distorting the
+     * image, and the remaining space is filled with the background color. The resulting image will match the
+     * constraining dimensions.
+     * - `stretch`: Stretches the image to fit the constraining dimensions exactly. The resulting image will fill the
+     * dimensions, and will not maintain the aspect ratio of the input image.
+     * - `crop`: Resizes the image to fill the width and height boundaries and crops any excess image data. The
+     * resulting image will match the width and height constraints without distorting the image. See the crop page for
+     * more information.
+     *
+     * @param string $fit Accepts the following values:
+     *                    - `contain`: Default. Resizes the image to fit within the width and height boundaries without
+     *                    cropping, distorting or altering the aspect ratio.
+     *                    - `max`: Resizes the image to fit within the width and height boundaries without cropping,
+     *                    distorting or altering the aspect ratio, and will also not increase the size of the image if
+     *                    it is smaller than the output size.
+     *                    - `fill`: Resizes the image to fit within the width and height boundaries without cropping or
+     *                    distorting the image, and the remaining space is filled with the background color. The
+     *                    resulting image will match the constraining dimensions.
+     *                    - `stretch`: Stretches the image to fit the constraining dimensions exactly. The resulting
+     *                    image will fill the dimensions, and will not maintain the aspect ratio of the input image.
+     *                    - `crop`: Resizes the image to fill the width and height boundaries and crops any excess
+     *                    image data. The resulting image will match the width and height constraints without
+     *                    distorting the image. See the crop page for more information.
+     *
+     * @return Watermarks
+     * @throws InvalidMarkFitException
+     */
+    public function markFit(string $fit = 'contain')
+    {
+        if ($fit !== Size::$FIT_CONTAIN &&
+            $fit !== Size::$FIT_CROP &&
+            $fit !== Size::$FIT_FILL &&
+            $fit !== Size::$FIT_MAX &&
+            $fit !== Size::$FIT_STRETCH
+        ) {
+            throw new InvalidMarkFitException();
+        }
+
+        $this->buildParams['markfit'] = $fit;
+
+        return $this;
+    }
+
+    /**
+     * Sets how far the watermark is away from the left and right edges of the image.
+     *
+     * Set in pixels, or using relative dimensions. Ignored if `markpos` is set to center.
+     *
+     * @param string $dimension
+     *
+     * @return Watermarks
+     * @throws InvalidDimensionException
+     */
+    public function markX(string $dimension)
+    {
+        $this->buildParams['markx'] = $this->parseDimension($dimension);
+
+        return $this;
+    }
+
+    /**
+     * Sets how far the watermark is away from the top and bottom edges of the image.
+     *
+     * Set in pixels, or using relative dimensions. Ignored if `markpos` is set to center.
+     *
+     * @param string $dimension
+     *
+     * @return Watermarks
+     * @throws InvalidDimensionException
+     */
+    public function markY(string $dimension)
+    {
+        $this->buildParams['marky'] = $this->parseDimension($dimension);
+
+        return $this;
+    }
+
+    /**
+     * Sets how far the watermark is away from edges of the image.
+     *
+     * Basically a shortcut for using both `markx` and `marky`. Set in pixels, or using relative dimensions. Ignored if
+     * `markpos` is set to center.
+     *
+     * @param string $dimension
+     *
+     * @return Watermarks
+     */
+    public function markPad(string $dimension)
+    {
+        $this->buildParams['markpad'] = $this->parseDimension($dimension);
+
+        return $this;
+    }
+
+    /**
+     * Sets where the watermark is positioned.
+     *
+     * Accepts `top-left`, `top`, `top-right`, `left`, `center`, `right`, `bottom-left`, `bottom`, `bottom-right`.
+     * Default is `center`.
+     *
+     * @param string $position Accepts :
+     *                         - `top-left`
+     *                         - `top`,
+     *                         - `top-right`,
+     *                         - `left`,
+     *                         - `center`,
+     *                         - `right`,
+     *                         - `bottom-left`,
+     *                         - `bottom`,
+     *                         - `bottom-right`.
+     *
+     * @return Watermarks
+     */
+    public function markPos(string $position = 'center')
+    {
+        if ($position !== static::$MARKPOS_TOP_LEFT &&
+            $position !== static::$MARKPOS_TOP &&
+            $position !== static::$MARKPOS_TOP_RIGHT &&
+            $position !== static::$MARKPOS_LEFT &&
+            $position !== static::$MARKPOS_CENTER &&
+            $position !== static::$MARKPOS_RIGHT &&
+            $position !== static::$MARKPOS_BOTTOM_LEFT &&
+            $position !== static::$MARKPOS_BOTTOM &&
+            $position !== static::$MARKPOS_BOTTOM_RIGHT
+        ) {
+            throw new InvalidMarkPositionException();
+        }
+
+        $this->buildParams['markpos'] = $position;
+
+        return $this;
+    }
+
+    /**
+     * Sets the opacity of the watermark.
+     *
+     * Use values between `0` and `100`, where `100` is fully opaque, and `0` is fully transparent. The default value
+     * is `100`.
+     *
+     * @param int $alpha
+     */
+    public function markAlpha(int $alpha = 100)
+    {
+        $alpha = max(0, $alpha);
+        $alpha = min($alpha, 100);
+
+        $this->buildParams['markalpha'] = $alpha;
+
+        return $this;
+    }
+}

--- a/src/Util/GlideUrl.php
+++ b/src/Util/GlideUrl.php
@@ -14,13 +14,14 @@ use AmpedWeb\GlideInABox\Traits\Flip;
 use AmpedWeb\GlideInABox\Traits\Orientation;
 use AmpedWeb\GlideInABox\Traits\PixelDensity;
 use AmpedWeb\GlideInABox\Traits\Size;
+use AmpedWeb\GlideInABox\Traits\Watermarks;
 use Illuminate\Support\Str;
 use League\Glide\Urls\UrlBuilder;
 use League\Glide\Urls\UrlBuilderFactory;
 
 class GlideUrl
 {
-    use Orientation, Flip, Crop, Size, PixelDensity, Adjustments, Effects, Border, Background, Encode;
+    use Orientation, Flip, Crop, Size, PixelDensity, Adjustments, Effects, Border, Watermarks, Background, Encode;
 
     /**
      * The filepath of our image being manipulated

--- a/tests/Feature/AdjustmentsTest.php
+++ b/tests/Feature/AdjustmentsTest.php
@@ -108,6 +108,11 @@ class AdjustmentsTest extends TestCase
         $this->assertSame($this->glideUrl->contrast(45), $this->glideUrl->con(45));
     }
 
+    public function testGammaIsAnAliasOfGam()
+    {
+        $this->assertSame($this->glideUrl->gamma(45), $this->glideUrl->gam(45));
+    }
+
     public function testSharpenIsAnAliasOfSharp()
     {
         $this->assertSame($this->glideUrl->sharpen(45), $this->glideUrl->sharp(45));

--- a/tests/Feature/WatermarksTest.php
+++ b/tests/Feature/WatermarksTest.php
@@ -1,0 +1,165 @@
+<?php
+
+
+namespace AmpedWeb\GlideInABox\Tests\Feature;
+
+
+use AmpedWeb\GlideInABox\Exceptions\InvalidMarkFitException;
+use AmpedWeb\GlideInABox\Exceptions\InvalidMarkPositionException;
+use AmpedWeb\GlideInABox\Tests\TestCase;
+use AmpedWeb\GlideInABox\Util\GlideUrl;
+
+class WatermarksTest extends TestCase
+{
+    /** @var GlideUrl */
+    protected $glideUrl;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->glideUrl = glide_url('cat.png');
+    }
+
+    public function testMarkIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->mark('foo.png'));
+    }
+
+    public function testMarkWidthIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markWidth(45));
+    }
+
+    public function testMarkHeightIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markHeight(50));
+    }
+
+    public function testMarkFitIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markFit());
+    }
+
+    public function testMarkXIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markX(45));
+    }
+
+    public function testMarkYIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markY(45));
+    }
+
+    public function testMarkPadIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markPad(5));
+    }
+
+    public function testMarkPosIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markPos());
+    }
+
+    public function testMarkAlphaIsFluent()
+    {
+        $this->assertSame($this->glideUrl, $this->glideUrl->markAlpha());
+    }
+
+    public function testMarkSetsCorrectValue()
+    {
+        $this->glideUrl->mark('foo.png');
+        $this->assertEquals('foo.png', $this->glideUrl->getParams()['mark']);
+    }
+
+    public function testMarkWidthSetsCorrectValue()
+    {
+        $this->glideUrl->markWidth(10);
+        $this->assertEquals(10, $this->glideUrl->getParams()['markw']);
+
+        $this->glideUrl->markWidth('5w');
+        $this->assertEquals('5w', $this->glideUrl->getParams()['markw']);
+    }
+
+    public function testMarkHeightSetsCorrectValue()
+    {
+        $this->glideUrl->markHeight(29);
+        $this->assertEquals('29', $this->glideUrl->getParams()['markh']);
+
+        $this->glideUrl->markHeight('70h');
+        $this->assertEquals('70h', $this->glideUrl->getParams()['markh']);
+    }
+
+    public function testMarkFitSetsCorrectValue()
+    {
+        foreach (['contain', 'max', 'fill', 'stretch', 'crop'] as $fit) {
+            $this->glideUrl->markFit($fit);
+            $this->assertEquals($fit, $this->glideUrl->getParams()['markfit']);
+        }
+    }
+
+    public function testMarkFitThrowsExceptionIfInvalidParameterIsPassed()
+    {
+        $this->expectException(InvalidMarkFitException::class);
+
+        $this->glideUrl->markFit('foo');
+    }
+
+    public function testMarkXSetsCorrectValue()
+    {
+        $this->glideUrl->markX(5);
+        $this->assertEquals(5, $this->glideUrl->getParams()['markx']);
+    }
+
+    public function testMarkYSetsCorrectValue()
+    {
+        $this->glideUrl->markY(9);
+        $this->assertEquals(9, $this->glideUrl->getParams()['marky']);
+    }
+
+    public function testMarkPadSetsCorrectValue()
+    {
+        $this->glideUrl->markPad(5);
+        $this->assertEquals(5, $this->glideUrl->getParams()['markpad']);
+    }
+
+    public function testMarkPosSetsCorrectValue()
+    {
+        foreach ([
+                     'top-left',
+                     'top',
+                     'top-right',
+                     'left',
+                     'center',
+                     'right',
+                     'bottom-left',
+                     'bottom',
+                     'bottom-right'
+                 ] as $position) {
+            $this->glideUrl->markPos($position);
+            $this->assertEquals($position, $this->glideUrl->getParams()['markpos']);
+        }
+    }
+
+    public function testMarkPosThrowsExceptionIfInvalidParameterIsPassed()
+    {
+        $this->expectException(InvalidMarkPositionException::class);
+
+        $this->glideUrl->markPos('foo');
+    }
+
+    public function testMarkAlphaSetsCorrectValue()
+    {
+        $this->glideUrl->markAlpha(45);
+        $this->assertEquals(45, $this->glideUrl->getParams()['markalpha']);
+    }
+
+    public function testMarkAlphaClampsValue()
+    {
+        $this->glideUrl->markAlpha(-54);
+        $this->assertEquals(0, $this->glideUrl->getParams()['markalpha']);
+
+        $this->glideUrl->markAlpha(999);
+        $this->assertEquals(100, $this->glideUrl->getParams()['markalpha']);
+    }
+}


### PR DESCRIPTION
This closes #7.

It also adds a missing unit test for the `Adjustments` trait, which brings line coverage to 100% (excluding config).