### PR TITLE
Fixed Typo Error in GlideInABox Namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ print glide_url($pathToYourImageFile)->preset('medium')->filter('sepia');
 There are also predefined constants if you prefer using those rather than strings, e.g:
 
 ```php
-use AmpedWeb\GlideInABox\Interfaces\Filter;
+use AmpedWeb\GlideUrl\Interfaces\Filter;
 
 glide_url($pathToYourImageFile)->preset('medium')->filter(Filter::SEPIA)->url();
 ```
@@ -79,7 +79,7 @@ You can also build a completely custom image with no preset.
 Below is a 200x100 px cropped webp image at 50% quality:
 
 ```php
-use AmpedWeb\GlideInABox\Interfaces\Fit;
+use AmpedWeb\GlideUrl\Interfaces\Fit;
 
 glide_url($pathToYourImageFile)->size(200,100)->fit(Fit::CROP)->webp(50)->url();
 ```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -64,9 +64,9 @@ $darkerImage = (string)glide_url('/path/to/your/image.jpg')->preset('list')->bri
 #### Chain as many manipulations as you want
 
 ```php
-use AmpedWeb\GlideInABox\Interfaces\Border;
-use AmpedWeb\GlideInABox\Interfaces\Crop;
-use AmpedWeb\GlideInABox\Interfaces\Filter;
+use AmpedWeb\GlideUrl\Interfaces\Border;
+use AmpedWeb\GlideUrl\Interfaces\Crop;
+use AmpedWeb\GlideUrl\Interfaces\Filter;
 
 $image = (string)glide_url('/path/to/your/image.jpg')->preset('list')
                                                      ->cropToPosition(400, 400, Crop::BOTTOM_LEFT)
@@ -88,9 +88,9 @@ $image = glide_url('/path/to/your/image.jpg')->size(300, 300)->fit('max')->jpeg(
 
 ### Using several manipulations
 ```php
-use AmpedWeb\GlideInABox\Interfaces\Border;
-use AmpedWeb\GlideInABox\Interfaces\Crop;
-use AmpedWeb\GlideInABox\Interfaces\Filter;
+use AmpedWeb\GlideUrl\Interfaces\Border;
+use AmpedWeb\GlideUrl\Interfaces\Crop;
+use AmpedWeb\GlideUrl\Interfaces\Filter;
 
 $image = (string)glide_url('/path/to/your/image.jpg')->cropToPosition(400, 400, Crop::BOTTOM_LEFT)
                                                      ->sharpen(20)

--- a/docs/glide-url-helper/crop.md
+++ b/docs/glide-url-helper/crop.md
@@ -52,7 +52,7 @@ glide_url('/path/to/your_amazing_image.jpeg')->cropToPosition(100,100,Crop::TOP_
 
 ```php
 
-    namespace AmpedWeb\GlideInABox\Interfaces\Crop;
+    namespace AmpedWeb\GlideUrl\Interfaces\Crop;
 
     Crop::TOP_LEFT // same as "crop-top-left"
     Crop::TOP // same as "top"

--- a/docs/glide-url-helper/effects.md
+++ b/docs/glide-url-helper/effects.md
@@ -62,7 +62,7 @@ glide_url('/path/to/your_amazing_image.jpeg')->filter(Filter::GREYSCALE)->url()
 #### Filter Constants
 
 ```php
-namespace AmpedWeb\GlideInABox\Interfaces\Effects;
+namespace AmpedWeb\GlideUrl\Interfaces\Filter;
 
 Filter::GREYSCALE // same as "greyscale"
 Filter::SEPIA // same as "sepia"

--- a/docs/glide-url-helper/flip.md
+++ b/docs/glide-url-helper/flip.md
@@ -37,7 +37,7 @@ glide_url('/path/to/your_amazing_image.jpeg')->flip(Flip::VERTICAL)->url()
 #### Flip Constants
 
 ```php
-namespace AmpedWeb\GlideInABox\Interfaces\Flip;
+namespace AmpedWeb\GlideUrl\Interfaces\Flip;
 
 Flip::VERTICAL // same as "v"
 Flip::HORIZONTAL // same as "h"

--- a/docs/glide-url-helper/orientation.md
+++ b/docs/glide-url-helper/orientation.md
@@ -38,7 +38,7 @@ glide_url('/path/to/your_amazing_image.jpeg')->orientation(Rotate::R90)->url()
 #### Orientation Constants
 
 ```php
-namespace AmpedWeb\GlideInABox\Interfaces\Orientation;
+namespace AmpedWeb\GlideUrl\Interfaces\Rotate;
 
 Rotate::AUTO // same as "auto"
 Rotate::R0 // same as "0"

--- a/docs/glide-url-helper/watermarks.md
+++ b/docs/glide-url-helper/watermarks.md
@@ -162,7 +162,7 @@ glide_url('/path/to/your_amazing_image.jpeg')
 #### Position Constants
 
 ```php
-namespace AmpedWeb\GlideInABox\Interfaces\Position;
+namespace AmpedWeb\GlideUrl\Interfaces\Position;
 
 Position::TOP_LEFT // same as "top-left"
 Position::TOP // same as "top"


### PR DESCRIPTION
This pull request addresses a typo error in the `GlideInABox` namespace. 

#### Which causes class not found error
```php
Class "AmpedWeb\GlideInABox\Interfaces\Filter" not found
```

Currently, most of the interfaces point to `GlideInABox` namespace, which is incorrect. 
This fix ensures that the interfaces within `GlideInABox` correctly reference the intended `GlideUrl` namespace.